### PR TITLE
feat(backend): merge Cevi Alpin two-date events into a single entry (…

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feature: add quick filters for course categories
+- feature: merge two start-only dates into a single event entry (Cevi Alpin pattern)
 
 ## Version 1.0.15, 23.03.2026
 

--- a/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImpl.java
+++ b/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImpl.java
@@ -11,13 +11,14 @@ import org.slf4j.LoggerFactory;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class HitobitoProviderImpl implements HitobitoProvider {
-    Logger logger = LoggerFactory.getLogger(HitobitoApi.class);
+    Logger logger = LoggerFactory.getLogger(HitobitoProviderImpl.class);
 
     private final HitobitoApiProvider provider;
 
@@ -97,6 +98,30 @@ class HitobitoProviderImpl implements HitobitoProvider {
 
     private static List<CeviEvent> toCeviEvents(HitobitoEvent event, Map<String, HitobitoEventDate> dateLoockup, Map<String, String> groupLookup,
                                                 Map<String, String> kindLookup) {
+        var dates = Arrays.stream(event.links().dates()).map(dateLoockup::get).toList();
+
+        if (shouldMergeDates(dates)) {
+            var start = dates.get(0);
+            var end = dates.get(1);
+            String location = !start.location().isBlank() ? start.location() : end.location();
+            return List.of(new CeviEvent(
+                    event.id(),
+                    event.name(),
+                    event.description() != null ? event.description() : "",
+                    event.external_application_link(),
+                    OffsetDateTime.parse(start.start_at()).toLocalDateTime(),
+                    OffsetDateTime.parse(end.start_at()).toLocalDateTime(),
+                    groupLookup.get(event.links().groups()[0]),
+                    location,
+                    (event.links().kind() != null && kindLookup.get(event.links().kind()) != null) ? kindLookup.get(event.links().kind()) : "N/A",
+                    event.links().kind() != null ? CeviEventType.COURSE : CeviEventType.EVENT,
+                    event.participant_count(),
+                    event.maximum_participants(),
+                    event.application_opening_at(),
+                    event.application_closing_at()
+            ));
+        }
+
         return Arrays.stream(event.links().dates()).map(d -> new CeviEvent(
                 event.id(),
                 event.name(),
@@ -113,5 +138,17 @@ class HitobitoProviderImpl implements HitobitoProvider {
                 event.application_opening_at(),
                 event.application_closing_at()
         )).toList();
+    }
+
+    private static boolean shouldMergeDates(List<HitobitoEventDate> dates) {
+        if (dates.size() != 2) return false;
+        var first = dates.get(0);
+        var second = dates.get(1);
+        if (first.finish_at() != null || second.finish_at() != null) return false;
+        long daysBetween = ChronoUnit.DAYS.between(
+                OffsetDateTime.parse(first.start_at()),
+                OffsetDateTime.parse(second.start_at())
+        );
+        return daysBetween >= 0 && daysBetween <= 14;
     }
 }

--- a/backend/src/test/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImplTest.java
+++ b/backend/src/test/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImplTest.java
@@ -1,0 +1,115 @@
+package ch.cevi.db.adapter.hitobito;
+
+import ch.cevi.db.adapter.EventFilter;
+import ch.cevi.db.adapter.domain.CeviEventType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HitobitoProviderImplTest {
+
+    private static final String GROUP_ID = "g1";
+    private static final String GROUP_NAME = "Cevi Alpin";
+    private static final String[] GROUPS = {GROUP_NAME};
+
+    private HitobitoProviderImpl sut(HitobitoEventPage... pages) {
+        return new HitobitoProviderImpl(() -> List.of(pages), GROUPS, GROUPS);
+    }
+
+    private HitobitoEventPage pageWithCourseEvent(String eventId, HitobitoEventDate... dates) {
+        var dateIds = java.util.Arrays.stream(dates).map(HitobitoEventDate::id).toArray(String[]::new);
+        var event = new HitobitoEvent(eventId, "Kurs", null, "https://db.cevi.ch/public_events/" + eventId,
+                new HitobitoLinks(dateIds, new String[]{GROUP_ID}, "k1"),
+                0, null, null, null);
+        var linked = new HitobitoLinked(dates, new HitobitoGroup[]{new HitobitoGroup(GROUP_ID, GROUP_NAME)},
+                new HitobitoEventKind[]{new HitobitoEventKind("k1", "Ski- und Snowboardtour")});
+        return new HitobitoEventPage(1, 1, null, new HitobitoEvent[]{event}, linked);
+    }
+
+    @Test
+    void should_merge_two_start_only_dates_into_single_event() {
+        var date1 = new HitobitoEventDate("d1", "2050-12-27T00:00:00.000+01:00", null, "Hospental");
+        var date2 = new HitobitoEventDate("d2", "2051-01-02T00:00:00.000+01:00", null, "");
+        var provider = sut(pageWithCourseEvent("1", date1, date2));
+
+        var events = provider.getEvents(EventFilter.emptyFilter());
+
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst().startsAt()).isEqualTo("2050-12-27T00:00:00");
+        assertThat(events.getFirst().finishAt()).isEqualTo("2051-01-02T00:00:00");
+        assertThat(events.getFirst().location()).isEqualTo("Hospental");
+    }
+
+    @Test
+    void should_use_second_location_when_first_is_blank() {
+        var date1 = new HitobitoEventDate("d1", "2050-06-13T00:00:00.000+02:00", null, "");
+        var date2 = new HitobitoEventDate("d2", "2050-06-14T00:00:00.000+02:00", null, "Haslital");
+        var provider = sut(pageWithCourseEvent("2", date1, date2));
+
+        var events = provider.getEvents(EventFilter.emptyFilter());
+
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst().location()).isEqualTo("Haslital");
+    }
+
+    @Test
+    void should_not_merge_when_one_date_has_finish_at() {
+        var date1 = new HitobitoEventDate("d1", "2050-05-30T00:00:00.000+02:00", "2050-05-31T00:00:00.000+02:00", "");
+        var date2 = new HitobitoEventDate("d2", "2050-06-05T00:00:00.000+02:00", null, "");
+        var provider = sut(pageWithCourseEvent("3", date1, date2));
+
+        var events = provider.getEvents(EventFilter.emptyFilter());
+
+        assertThat(events).hasSize(2);
+    }
+
+    @Test
+    void should_not_merge_when_gap_exceeds_14_days() {
+        var date1 = new HitobitoEventDate("d1", "2050-01-01T00:00:00.000+01:00", null, "");
+        var date2 = new HitobitoEventDate("d2", "2050-02-01T00:00:00.000+01:00", null, "");
+        var provider = sut(pageWithCourseEvent("4", date1, date2));
+
+        var events = provider.getEvents(EventFilter.emptyFilter());
+
+        assertThat(events).hasSize(2);
+    }
+
+    @Test
+    void should_not_merge_single_date() {
+        var date1 = new HitobitoEventDate("d1", "2050-06-01T00:00:00.000+02:00", null, "");
+        var provider = sut(pageWithCourseEvent("5", date1));
+
+        var events = provider.getEvents(EventFilter.emptyFilter());
+
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst().finishAt()).isNull();
+    }
+
+    @Test
+    void should_not_merge_more_than_two_dates() {
+        var date1 = new HitobitoEventDate("d1", "2050-07-01T00:00:00.000+02:00", null, "");
+        var date2 = new HitobitoEventDate("d2", "2050-07-05T00:00:00.000+02:00", null, "");
+        var date3 = new HitobitoEventDate("d3", "2050-07-10T00:00:00.000+02:00", null, "");
+        var provider = sut(pageWithCourseEvent("6", date1, date2, date3));
+
+        var events = provider.getEvents(EventFilter.emptyFilter());
+
+        assertThat(events).hasSize(3);
+    }
+
+    @Test
+    void merged_event_has_correct_type_and_kind() {
+        var date1 = new HitobitoEventDate("d1", "2050-12-27T00:00:00.000+01:00", null, "");
+        var date2 = new HitobitoEventDate("d2", "2051-01-02T00:00:00.000+01:00", null, "");
+        var provider = sut(pageWithCourseEvent("7", date1, date2));
+
+        var events = provider.getEvents(EventFilter.emptyFilter());
+
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst().eventType()).isEqualTo(CeviEventType.COURSE);
+        assertThat(events.getFirst().kind()).isEqualTo("Ski- und Snowboardtour");
+        assertThat(events.getFirst().group()).isEqualTo(GROUP_NAME);
+    }
+}


### PR DESCRIPTION
…#508)

Cevi Alpin records events with two occurrences — first has only a start date, second has only a start date representing the end. These are now merged into a single CeviEvent with the correct start and finish date instead of appearing as two separate entries. Merging only happens when the event has exactly two dates, both without finish_at, and the span is ≤ 14 days.