### PR TITLE
feat: use Hitobito course state to determine if application is open (…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@
 
 All commands run via Docker; no local runtimes required.
 
+**Note on `backend:test` output:** The final `Tests run:` summary belongs to Failsafe (IT-tests only). Surefire unit test results (`*Test.java`) appear earlier in the log — don't confuse the two.
+
 ```bash
 # Frontend
 tooling/docker.sh frontend:devInt       # Dev server against int backend (port 4200)

--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feature: use Hitobito course state to determine if application is open for courses
 - feature: add quick filters for course categories
 
 ## Version 1.0.15, 23.03.2026

--- a/backend/src/main/java/ch/cevi/db/adapter/domain/CeviEvent.java
+++ b/backend/src/main/java/ch/cevi/db/adapter/domain/CeviEvent.java
@@ -6,7 +6,8 @@ import java.util.Objects;
 
 public record CeviEvent(String id, String name, String description, String applicationLink, LocalDateTime startsAt,
                         LocalDateTime finishAt, String group, String location, String kind, CeviEventType eventType,
-                        int participantsCount, Integer maximumParticipants, LocalDate applicationOpeningAt, LocalDate applicationClosingAt) {
+                        int participantsCount, Integer maximumParticipants, LocalDate applicationOpeningAt, LocalDate applicationClosingAt,
+                        String state) {
     public CeviEvent {
         Objects.requireNonNull(id);
         Objects.requireNonNull(name, () -> "Name mustn't be null for event " + id);
@@ -24,23 +25,27 @@ public record CeviEvent(String id, String name, String description, String appli
     }
 
     public CeviEvent withKind(String kind) {
-        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt);
+        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt, state);
     }
 
     public CeviEvent withParticipantsCount(Integer participantsCount) {
-        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt);
+        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt, state);
     }
 
     public CeviEvent withMaximumParticipants(Integer maximumParticipants) {
-        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt);
+        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt, state);
     }
 
     public CeviEvent withApplicationOpeningAt(LocalDate applicationOpeningAt) {
-        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt);
+        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt, state);
     }
 
     public CeviEvent withApplicationClosingAt(LocalDate applicationClosingAt) {
-        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt);
+        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt, state);
+    }
+
+    public CeviEvent withState(String state) {
+        return new CeviEvent(id, name, description, applicationLink, startsAt, finishAt, group, location, kind, eventType, participantsCount, maximumParticipants, applicationOpeningAt, applicationClosingAt, state);
     }
 
     public boolean hasLimitedCapacity() {
@@ -52,6 +57,9 @@ public record CeviEvent(String id, String name, String description, String appli
     }
 
     public boolean isApplicationOpen() {
+        if (this.eventType == CeviEventType.COURSE) {
+            return "application_open".equals(this.state);
+        }
         return (this.applicationClosingAt == null || LocalDate.now().isBefore(this.applicationClosingAt) || LocalDate.now().isEqual(this.applicationClosingAt)) &&
                 (this.applicationOpeningAt == null || LocalDate.now().isAfter(this.applicationOpeningAt) || LocalDate.now().isEqual(this.applicationOpeningAt));
     }

--- a/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoEvent.java
+++ b/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoEvent.java
@@ -4,7 +4,8 @@ import java.time.LocalDate;
 import java.util.Objects;
 
 public record HitobitoEvent(String id, String name, String description, String external_application_link, HitobitoLinks links,
-                            int participant_count, Integer maximum_participants, LocalDate application_opening_at, LocalDate application_closing_at) {
+                            int participant_count, Integer maximum_participants, LocalDate application_opening_at, LocalDate application_closing_at,
+                            String state) {
     public HitobitoEvent {
         Objects.requireNonNull(id);
         Objects.requireNonNull(name);

--- a/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImpl.java
+++ b/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImpl.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class HitobitoProviderImpl implements HitobitoProvider {
-    Logger logger = LoggerFactory.getLogger(HitobitoApi.class);
+    Logger logger = LoggerFactory.getLogger(HitobitoProviderImpl.class);
 
     private final HitobitoApiProvider provider;
 
@@ -111,7 +111,8 @@ class HitobitoProviderImpl implements HitobitoProvider {
                 event.participant_count(),
                 event.maximum_participants(),
                 event.application_opening_at(),
-                event.application_closing_at()
+                event.application_closing_at(),
+                event.state()
         )).toList();
     }
 }

--- a/backend/src/main/resources/fake_data/course0.json
+++ b/backend/src/main/resources/fake_data/course0.json
@@ -17,7 +17,7 @@
       "application_opening_at": "2030-11-22",
       "application_closing_at": "2031-01-15",
       "application_conditions": "Bla",
-      "state": "closed",
+      "state": "application_open",
       "teamer_count": 16,
       "external_application_link": "https://db.cevi.ch/groups/2569/public_events/3208",
       "links": {

--- a/backend/src/test/java/ch/cevi/db/adapter/CeviEventTest.java
+++ b/backend/src/test/java/ch/cevi/db/adapter/CeviEventTest.java
@@ -7,7 +7,7 @@ import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CeviEventTest {
+class CeviEventTest {
     @Test
     void should_allow_more_than_max_participants() {
         var overbooked = CeviEventFixture.ceviEvent()
@@ -84,5 +84,35 @@ public class CeviEventTest {
                 .withApplicationOpeningAt(LocalDate.now().minusDays(2))
                 .withApplicationClosingAt(LocalDate.now().minusDays(1));
         assertThat(closedInThePast.isApplicationOpen()).isFalse();
+    }
+
+    @Test
+    void course_should_be_open_for_application_when_state_is_application_open() {
+        var course = CeviEventFixture.ceviCourse();
+        assertThat(course.isApplicationOpen()).isTrue();
+
+        var withExplicitState = CeviEventFixture.ceviCourse().withState("application_open");
+        assertThat(withExplicitState.isApplicationOpen()).isTrue();
+    }
+
+    @Test
+    void course_should_not_be_open_for_application_when_state_is_not_application_open() {
+        var closed = CeviEventFixture.ceviCourse().withState("application_closed");
+        assertThat(closed.isApplicationOpen()).isFalse();
+
+        var closedOtherState = CeviEventFixture.ceviCourse().withState("closed");
+        assertThat(closedOtherState.isApplicationOpen()).isFalse();
+
+        var nullState = CeviEventFixture.ceviCourse().withState(null);
+        assertThat(nullState.isApplicationOpen()).isFalse();
+    }
+
+    @Test
+    void course_application_open_ignores_dates() {
+        var courseWithFutureDates = CeviEventFixture.ceviCourse()
+                .withState("application_closed")
+                .withApplicationOpeningAt(LocalDate.now().minusDays(1))
+                .withApplicationClosingAt(LocalDate.now().plusDays(1));
+        assertThat(courseWithFutureDates.isApplicationOpen()).isFalse();
     }
 }

--- a/backend/src/test/java/ch/cevi/db/adapter/EventControllerTests.java
+++ b/backend/src/test/java/ch/cevi/db/adapter/EventControllerTests.java
@@ -349,11 +349,16 @@ class EventControllerTests {
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
         List<CeviEvent> events = objectMapper.readValue(content, new TypeReference<>() {});
-        assertThat(events).hasSize(12);
+        assertThat(events).hasSize(14);
 
         // an event from FGI
         var ga = events.stream().filter(e -> e.id().equals("3213")).findFirst().orElseThrow();
         assertThat(ga.name()).isEqualTo("European YWCA General Assembly 2030");
         assertThat(ga.eventType()).isEqualTo(CeviEventType.EVENT);
+
+        // courses with state=application_open appear in results
+        var courses = events.stream().filter(e -> e.id().equals("3208")).toList();
+        assertThat(courses).hasSize(2)
+                .allMatch(e -> e.eventType() == CeviEventType.COURSE);
     }
 }

--- a/backend/src/test/java/ch/cevi/db/adapter/fixtures/CeviEventFixture.java
+++ b/backend/src/test/java/ch/cevi/db/adapter/fixtures/CeviEventFixture.java
@@ -21,6 +21,25 @@ public class CeviEventFixture {
                 3,
                 null,
                 null,
+                null,
                 null);
+    }
+
+    public static CeviEvent ceviCourse() {
+        return new CeviEvent("3208",
+                "Gruppenleiterkurs GLK 2030",
+                "Du willst eine Gruppe selbstständig leiten?",
+                "https://db.cevi.ch/groups/2569/public_events/3208",
+                LocalDateTime.of(2030, Month.APRIL, 8, 9, 0, 0),
+                LocalDateTime.of(2030, Month.APRIL, 15, 17, 0, 0),
+                "Cevi Regionalverband AG-SO-LU-ZG",
+                "Stäfa",
+                "J+S-Leiter*innenkurs LS/T Jugendliche",
+                CeviEventType.COURSE,
+                10,
+                29,
+                null,
+                null,
+                "application_open");
     }
 }

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feature: use Hitobito course state to determine if application is open for courses
 - feature: add quick filters for course categories
 - feature: reflect the chosen filters in the uri
 - feature: add French translation with language toggle in header (native Angular i18n)

--- a/frontend/src/app/event/components/eventlist.component.spec.ts
+++ b/frontend/src/app/event/components/eventlist.component.spec.ts
@@ -45,6 +45,7 @@ describe('EventlistComponent', () => {
       maximumParticipants: 20,
       applicationClosingAt: null,
       applicationOpeningAt: null,
+      state: 'application_open',
     },
   ];
 
@@ -206,8 +207,22 @@ describe('EventlistComponent', () => {
   it('hasFreeSeats', () => {
     expect(sut.hasFreeSeats(events[0])).toBe('Ja');
   });
-  it('isApplicationOpen', () => {
+  it('isApplicationOpen for course with state application_open', () => {
     expect(sut.isApplicationOpen(events[0])).toBe('Ja');
+  });
+  it('isApplicationOpen for course with state application_closed', () => {
+    const closedCourse = { ...events[0], state: 'application_closed' };
+    expect(sut.isApplicationOpen(closedCourse)).toBe('Nein');
+  });
+  it('isApplicationOpen for event uses date logic', () => {
+    const openEvent: CeviEvent = {
+      ...events[0],
+      eventType: 'EVENT',
+      state: null,
+      applicationOpeningAt: null,
+      applicationClosingAt: null,
+    };
+    expect(sut.isApplicationOpen(openEvent)).toBe('Ja');
   });
 
   describe('URL parameter synchronization', () => {

--- a/frontend/src/app/event/components/eventlist.component.ts
+++ b/frontend/src/app/event/components/eventlist.component.ts
@@ -240,6 +240,11 @@ export class EventListComponent implements OnInit {
   }
 
   isApplicationOpen(element: CeviEvent) {
+    if (element.eventType === 'COURSE') {
+      return element.state === 'application_open'
+        ? $localize`:@@common.yes:Ja`
+        : $localize`:@@common.no:Nein`;
+    }
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     return (element.applicationClosingAt === null ||

--- a/frontend/src/app/event/services/event.service.ts
+++ b/frontend/src/app/event/services/event.service.ts
@@ -16,6 +16,7 @@ export interface CeviEvent {
   maximumParticipants: number | null;
   applicationOpeningAt: string | null;
   applicationClosingAt: string | null;
+  state: string | null;
 }
 
 export interface CeviEventFilter {


### PR DESCRIPTION
…#507)

For courses, use the `state` field from the Hitobito API (`application_open` / `application_closed`) instead of deriving open status from date ranges. Events continue to use the existing date-based logic.