### PR TITLE
feat(frontend): add reset filter button (#235)

### DIFF
--- a/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImpl.java
+++ b/backend/src/main/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImpl.java
@@ -118,7 +118,8 @@ class HitobitoProviderImpl implements HitobitoProvider {
                     event.participant_count(),
                     event.maximum_participants(),
                     event.application_opening_at(),
-                    event.application_closing_at()
+                    event.application_closing_at(),
+                    event.state()
             ));
         }
 

--- a/backend/src/test/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImplTest.java
+++ b/backend/src/test/java/ch/cevi/db/adapter/hitobito/HitobitoProviderImplTest.java
@@ -22,7 +22,7 @@ class HitobitoProviderImplTest {
         var dateIds = java.util.Arrays.stream(dates).map(HitobitoEventDate::id).toArray(String[]::new);
         var event = new HitobitoEvent(eventId, "Kurs", null, "https://db.cevi.ch/public_events/" + eventId,
                 new HitobitoLinks(dateIds, new String[]{GROUP_ID}, "k1"),
-                0, null, null, null);
+                0, null, null, null, null);
         var linked = new HitobitoLinked(dates, new HitobitoGroup[]{new HitobitoGroup(GROUP_ID, GROUP_NAME)},
                 new HitobitoEventKind[]{new HitobitoEventKind("k1", "Ski- und Snowboardtour")});
         return new HitobitoEventPage(1, 1, null, new HitobitoEvent[]{event}, linked);

--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feature: add reset button to clear all filters at once
 - feature: use Hitobito course state to determine if application is open for courses
 - feature: add quick filters for course categories
 - feature: reflect the chosen filters in the uri

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/material": "21.2.8",
         "@angular/platform-browser": "21.2.10",
         "@angular/router": "21.2.10",
+        "material-icons": "^1.13.14",
         "rxjs": "7.8.2",
         "tslib": "2.8.1",
         "zone.js": "0.16.1"
@@ -8571,6 +8572,12 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/material-icons": {
+      "version": "1.13.14",
+      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.13.14.tgz",
+      "integrity": "sha512-kZOfc7xCC0rAT8Q3DQixYAeT+tBqZnxkseQtp2bxBxz7q5pMAC+wmit7vJn1g/l7wRU+HEPq23gER4iPjGs5Cg==",
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,27 +19,27 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "21.2.10",
-    "@angular/localize": "21.2.10",
     "@angular/cdk": "21.2.8",
     "@angular/common": "21.2.10",
     "@angular/compiler": "21.2.10",
     "@angular/core": "21.2.10",
     "@angular/forms": "21.2.10",
+    "@angular/localize": "21.2.10",
     "@angular/material": "21.2.8",
     "@angular/platform-browser": "21.2.10",
     "@angular/router": "21.2.10",
+    "material-icons": "^1.13.14",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",
     "zone.js": "0.16.1"
   },
   "devDependencies": {
-    "angular-eslint": "21.3.1",
     "@angular/build": "21.2.8",
     "@angular/cli": "21.2.8",
     "@angular/compiler-cli": "21.2.10",
-    "@types/jasmine": "6.0.0",
-    "typescript-eslint": "8.59.0",
     "@eslint/js": "10.0.1",
+    "@types/jasmine": "6.0.0",
+    "angular-eslint": "21.3.1",
     "eslint": "10.2.1",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-prettier": "5.5.5",
@@ -51,6 +51,7 @@
     "karma-jasmine-html-reporter": "2.2.0",
     "prettier": "3.8.3",
     "prettier-eslint": "16.4.2",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.59.0"
   }
 }

--- a/frontend/src/app/event/components/eventlist.component.html
+++ b/frontend/src/app/event/components/eventlist.component.html
@@ -21,66 +21,77 @@
       }
     </mat-chip-set>
   </div>
-  <span i18n="@@filter.label">Filter:</span>
-  <mat-form-field>
-    <mat-label i18n="@@filter.organisation">Organisation</mat-label>
-    <mat-select multiple [formControl]="this.organisationFilter">
-      <app-select-check-all
-        [model]="this.organisationFilter"
-        [values]="this.organisations"></app-select-check-all>
-      @for (organisation of organisations; track organisation) {
-        <mat-option [value]="organisation">{{ organisation }}</mat-option>
-      }
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label i18n="@@filter.type">Typ</mat-label>
-    <mat-select
-      (selectionChange)="filterByEventType($event)"
-      [value]="this.filter.eventType">
-      <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
-      @for (type of types; track type) {
-        <mat-option [value]="type">{{
-          this.translateEventTypes(type)
-        }}</mat-option>
-      }
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label i18n="@@filter.nameSearch">Text im Name</mat-label>
-    <input type="text" [formControl]="this.nameFilter" matInput />
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label i18n="@@filter.kursart">Kursart</mat-label>
-    <mat-select
-      multiple
-      (selectionChange)="filterByKursart($event)"
-      [value]="filter.kursarten ?? []">
-      @for (kursart of kursarten; track kursart) {
-        <mat-option [value]="kursart">{{ kursart }}</mat-option>
-      }
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label i18n="@@filter.freeSeats">Freie Plätze</mat-label>
-    <mat-select
-      (selectionChange)="filterByAvailablePlaces($event)"
-      [value]="this.filter.hasAvailablePlaces">
-      <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
-      <mat-option [value]="true" i18n="@@common.yes">Ja</mat-option>
-      <mat-option [value]="false" i18n="@@common.no">Nein</mat-option>
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field>
-    <mat-label i18n="@@filter.applicationOpen">Offen zur Anmeldung</mat-label>
-    <mat-select
-      (selectionChange)="filterByIsApplicationOpen($event)"
-      [value]="this.filter.isApplicationOpen">
-      <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
-      <mat-option [value]="true" i18n="@@common.yes">Ja</mat-option>
-      <mat-option [value]="false" i18n="@@common.no">Nein</mat-option>
-    </mat-select>
-  </mat-form-field>
+  <div class="filter-bar">
+    <span i18n="@@filter.label">Filter:</span>
+    <mat-form-field>
+      <mat-label i18n="@@filter.organisation">Organisation</mat-label>
+      <mat-select multiple [formControl]="this.organisationFilter">
+        <app-select-check-all
+          [model]="this.organisationFilter"
+          [values]="this.organisations"></app-select-check-all>
+        @for (organisation of organisations; track organisation) {
+          <mat-option [value]="organisation">{{ organisation }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label i18n="@@filter.type">Typ</mat-label>
+      <mat-select
+        (selectionChange)="filterByEventType($event)"
+        [value]="this.filter.eventType">
+        <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
+        @for (type of types; track type) {
+          <mat-option [value]="type">{{
+            this.translateEventTypes(type)
+          }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label i18n="@@filter.nameSearch">Text im Name</mat-label>
+      <input type="text" [formControl]="this.nameFilter" matInput />
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label i18n="@@filter.kursart">Kursart</mat-label>
+      <mat-select
+        multiple
+        (selectionChange)="filterByKursart($event)"
+        [value]="filter.kursarten ?? []">
+        @for (kursart of kursarten; track kursart) {
+          <mat-option [value]="kursart">{{ kursart }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label i18n="@@filter.freeSeats">Freie Plätze</mat-label>
+      <mat-select
+        (selectionChange)="filterByAvailablePlaces($event)"
+        [value]="this.filter.hasAvailablePlaces">
+        <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
+        <mat-option [value]="true" i18n="@@common.yes">Ja</mat-option>
+        <mat-option [value]="false" i18n="@@common.no">Nein</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label i18n="@@filter.applicationOpen">Offen zur Anmeldung</mat-label>
+      <mat-select
+        (selectionChange)="filterByIsApplicationOpen($event)"
+        [value]="this.filter.isApplicationOpen">
+        <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
+        <mat-option [value]="true" i18n="@@common.yes">Ja</mat-option>
+        <mat-option [value]="false" i18n="@@common.no">Nein</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button
+      mat-stroked-button
+      class="filter-bar__reset"
+      [disabled]="!hasActiveFilter"
+      (click)="resetFilter()"
+      i18n="@@filter.reset">
+      <mat-icon>filter_alt_off</mat-icon>
+      Filter zurücksetzen
+    </button>
+  </div>
 }
 
 @if (this.isLoadingMasterdata || this.isLoading) {

--- a/frontend/src/app/event/components/eventlist.component.scss
+++ b/frontend/src/app/event/components/eventlist.component.scss
@@ -10,3 +10,15 @@
     white-space: nowrap;
   }
 }
+
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+
+  &__reset {
+    margin-left: auto;
+  }
+}

--- a/frontend/src/app/event/components/eventlist.component.spec.ts
+++ b/frontend/src/app/event/components/eventlist.component.spec.ts
@@ -204,6 +204,68 @@ describe('EventlistComponent', () => {
       isApplicationOpen: true,
     } as CeviEventFilter);
   });
+  it('hasActiveFilter returns false when no filter is set', () => {
+    sut.filter = {} as CeviEventFilter;
+    expect(sut.hasActiveFilter).toBeFalse();
+  });
+  it('hasActiveFilter returns true when eventType is set', () => {
+    sut.filter = { eventType: 'COURSE' } as CeviEventFilter;
+    expect(sut.hasActiveFilter).toBeTrue();
+  });
+  it('hasActiveFilter returns true when groups are set', () => {
+    sut.filter = { groups: ['Cevi Alpin'] } as CeviEventFilter;
+    expect(sut.hasActiveFilter).toBeTrue();
+  });
+  it('hasActiveFilter returns true when nameContains is set', () => {
+    sut.filter = { nameContains: 'GLK' } as CeviEventFilter;
+    expect(sut.hasActiveFilter).toBeTrue();
+  });
+  it('hasActiveFilter returns true when kursarten are set', () => {
+    sut.filter = { kursarten: ['J+S'] } as CeviEventFilter;
+    expect(sut.hasActiveFilter).toBeTrue();
+  });
+  it('hasActiveFilter returns true when hasAvailablePlaces is set', () => {
+    sut.filter = { hasAvailablePlaces: true } as CeviEventFilter;
+    expect(sut.hasActiveFilter).toBeTrue();
+  });
+  it('hasActiveFilter returns true when isApplicationOpen is set', () => {
+    sut.filter = { isApplicationOpen: false } as CeviEventFilter;
+    expect(sut.hasActiveFilter).toBeTrue();
+  });
+  it('resetFilter clears all filters', () => {
+    spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
+    sut.ngOnInit();
+    sut.activePreset = KURSART_PRESETS[0];
+    sut.resetFilter();
+    expect(sut.filter).toEqual({} as CeviEventFilter);
+    expect(sut.nameFilter.getRawValue()).toEqual('');
+    expect(sut.organisationFilter.getRawValue()).toEqual([]);
+    expect(sut.activePreset).toBeNull();
+  });
+  it('resetFilter reloads events', () => {
+    const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
+      of(events)
+    );
+    sut.resetFilter();
+    expect(fnc).toHaveBeenCalledWith({} as CeviEventFilter);
+  });
+  it('resetFilter clears all url params', () => {
+    sut.resetFilter();
+    expect(router.navigate).toHaveBeenCalledWith(
+      [],
+      jasmine.objectContaining({
+        queryParams: jasmine.objectContaining({
+          organisation: null,
+          type: null,
+          text: null,
+          kursart: null,
+          freeSeats: null,
+          applicationOpen: null,
+        }),
+        replaceUrl: true,
+      })
+    );
+  });
   it('hasFreeSeats', () => {
     expect(sut.hasFreeSeats(events[0])).toBe('Ja');
   });

--- a/frontend/src/app/event/components/eventlist.component.ts
+++ b/frontend/src/app/event/components/eventlist.component.ts
@@ -7,6 +7,8 @@ import { MatInputModule } from '@angular/material/input';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
@@ -34,6 +36,8 @@ import {
   selector: 'app-event-list',
   imports: [
     SelectCheckAllComponent,
+    MatButtonModule,
+    MatIconModule,
     MatChipsModule,
     MatProgressSpinnerModule,
     MatTableModule,
@@ -192,6 +196,26 @@ export class EventListComponent implements OnInit {
 
   filterByIsApplicationOpen($event: MatSelectChange) {
     this.filter.isApplicationOpen = $event.value;
+    this.loadEventsWithFilter();
+    this.updateUrlParams();
+  }
+
+  get hasActiveFilter(): boolean {
+    return !!(
+      this.filter.groups?.length ||
+      this.filter.eventType ||
+      this.filter.nameContains?.trim().length ||
+      this.filter.kursarten?.length ||
+      this.filter.hasAvailablePlaces != null ||
+      this.filter.isApplicationOpen != null
+    );
+  }
+
+  resetFilter() {
+    this.filter = {} as CeviEventFilter;
+    this.nameFilter.setValue('', { emitEvent: false });
+    this.organisationFilter.setValue([], { emitEvent: false });
+    this.activePreset = null;
     this.loadEventsWithFilter();
     this.updateUrlParams();
   }

--- a/frontend/src/locale/messages.fr.xlf
+++ b/frontend/src/locale/messages.fr.xlf
@@ -70,6 +70,10 @@
         <source>Filter:</source>
         <target>Filtres :</target>
       </trans-unit>
+      <trans-unit id="filter.reset" datatype="html">
+        <source>Filter zurücksetzen</source>
+        <target>Réinitialiser les filtres</target>
+      </trans-unit>
       <trans-unit id="filter.organisation" datatype="html">
         <source>Organisation</source>
         <target>Organisation</target>

--- a/frontend/src/locale/messages.xlf
+++ b/frontend/src/locale/messages.xlf
@@ -121,6 +121,13 @@
           <context context-type="linenumber">24,26</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="filter.reset" datatype="html">
+        <source>Filter zurücksetzen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/event/components/eventlist.component.html</context>
+          <context context-type="linenumber">26,30</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="filter.organisation" datatype="html">
         <source>Organisation</source>
         <context-group purpose="location">

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,4 +1,5 @@
 @use 'app/core/fonts/Montserrat';
+@import 'material-icons/iconfont/material-icons.css';
 $main-font: 'Montserrat Light';
 $text-size-normal: 14px;
 


### PR DESCRIPTION
Add a "Filter zurücksetzen" button that clears all active filters at once. The button is disabled when no filter is active and also clears active presets and URL params.