### PR TITLE
feat(frontend): implement filter modal (#234)

### DIFF
--- a/frontend/CHANGELOG.md
+++ b/frontend/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feature: filter modal — alle Filter in eigenem Fenster über "Weitere Filter"-Button
 - feature: add reset button to clear all filters at once
 - feature: use Hitobito course state to determine if application is open for courses
 - feature: add quick filters for course categories

--- a/frontend/src/app/event/components/eventlist.component.html
+++ b/frontend/src/app/event/components/eventlist.component.html
@@ -20,77 +20,24 @@
         >
       }
     </mat-chip-set>
-  </div>
-  <div class="filter-bar">
-    <span i18n="@@filter.label">Filter:</span>
-    <mat-form-field>
-      <mat-label i18n="@@filter.organisation">Organisation</mat-label>
-      <mat-select multiple [formControl]="this.organisationFilter">
-        <app-select-check-all
-          [model]="this.organisationFilter"
-          [values]="this.organisations"></app-select-check-all>
-        @for (organisation of organisations; track organisation) {
-          <mat-option [value]="organisation">{{ organisation }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label i18n="@@filter.type">Typ</mat-label>
-      <mat-select
-        (selectionChange)="filterByEventType($event)"
-        [value]="this.filter.eventType">
-        <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
-        @for (type of types; track type) {
-          <mat-option [value]="type">{{
-            this.translateEventTypes(type)
-          }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label i18n="@@filter.nameSearch">Text im Name</mat-label>
-      <input type="text" [formControl]="this.nameFilter" matInput />
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label i18n="@@filter.kursart">Kursart</mat-label>
-      <mat-select
-        multiple
-        (selectionChange)="filterByKursart($event)"
-        [value]="filter.kursarten ?? []">
-        @for (kursart of kursarten; track kursart) {
-          <mat-option [value]="kursart">{{ kursart }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label i18n="@@filter.freeSeats">Freie Plätze</mat-label>
-      <mat-select
-        (selectionChange)="filterByAvailablePlaces($event)"
-        [value]="this.filter.hasAvailablePlaces">
-        <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
-        <mat-option [value]="true" i18n="@@common.yes">Ja</mat-option>
-        <mat-option [value]="false" i18n="@@common.no">Nein</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
-      <mat-label i18n="@@filter.applicationOpen">Offen zur Anmeldung</mat-label>
-      <mat-select
-        (selectionChange)="filterByIsApplicationOpen($event)"
-        [value]="this.filter.isApplicationOpen">
-        <mat-option [value]="null" i18n="@@common.all">Alle</mat-option>
-        <mat-option [value]="true" i18n="@@common.yes">Ja</mat-option>
-        <mat-option [value]="false" i18n="@@common.no">Nein</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <button
-      mat-stroked-button
-      class="filter-bar__reset"
-      [disabled]="!hasActiveFilter"
-      (click)="resetFilter()"
-      i18n="@@filter.reset">
-      <mat-icon>filter_alt_off</mat-icon>
-      Filter zurücksetzen
-    </button>
+    <div class="filter-presets__actions">
+      <button
+        mat-stroked-button
+        (click)="openFilterModal()"
+        [matBadge]="activeModalFilterCount"
+        [matBadgeHidden]="activeModalFilterCount === 0"
+        matBadgeColor="primary">
+        <mat-icon>tune</mat-icon>
+        <span i18n="@@filter.moreFilters">Weitere Filter</span>
+      </button>
+      <button
+        mat-stroked-button
+        [disabled]="!hasActiveFilter"
+        (click)="resetFilter()">
+        <mat-icon>filter_alt_off</mat-icon>
+        <span i18n="@@filter.reset">Filter zurücksetzen</span>
+      </button>
+    </div>
   </div>
 }
 

--- a/frontend/src/app/event/components/eventlist.component.scss
+++ b/frontend/src/app/event/components/eventlist.component.scss
@@ -9,16 +9,11 @@
     font-weight: 500;
     white-space: nowrap;
   }
-}
 
-.filter-bar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
-
-  &__reset {
+  &__actions {
     margin-left: auto;
+    display: flex;
+    gap: 8px;
+    align-items: center;
   }
 }

--- a/frontend/src/app/event/components/eventlist.component.spec.ts
+++ b/frontend/src/app/event/components/eventlist.component.spec.ts
@@ -1,9 +1,4 @@
-import {
-  ComponentFixture,
-  fakeAsync,
-  TestBed,
-  tick,
-} from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EventListComponent } from './eventlist.component';
 import {
   CeviEvent,
@@ -11,7 +6,6 @@ import {
   EventService,
 } from '../services/event.service';
 import { Masterdata, MasterdataService } from '../services/masterdata.service';
-import { MatSelectChange } from '@angular/material/select';
 import { of } from 'rxjs';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import {
@@ -24,13 +18,16 @@ import {
   provideRouter,
   Router,
 } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 import { KURSART_PRESETS } from '../models/kursart-preset';
+import { FilterModalComponent } from './filter-modal.component';
 
 describe('EventlistComponent', () => {
   let fixture: ComponentFixture<EventListComponent>;
   let sut: EventListComponent;
   let eventService: EventService;
   let router: Router;
+  let dialogSpy: jasmine.SpyObj<MatDialog>;
 
   const events: CeviEvent[] = [
     {
@@ -56,6 +53,9 @@ describe('EventlistComponent', () => {
   };
 
   beforeEach(async () => {
+    dialogSpy = jasmine.createSpyObj('MatDialog', ['open']);
+    dialogSpy.open.and.returnValue({} as any);
+
     TestBed.configureTestingModule({
       imports: [EventListComponent],
       providers: [
@@ -87,6 +87,7 @@ describe('EventlistComponent', () => {
             ),
           },
         },
+        { provide: MatDialog, useValue: dialogSpy },
       ],
     }).compileComponents();
 
@@ -96,6 +97,7 @@ describe('EventlistComponent', () => {
     fixture = TestBed.createComponent(EventListComponent);
     sut = fixture.componentInstance;
   });
+
   it('loaded masterdata and events', () => {
     sut.ngOnInit();
     expect(sut.kursarten.length).toEqual(1);
@@ -105,53 +107,17 @@ describe('EventlistComponent', () => {
     expect(sut.isLoadingMasterdata).toEqual(false);
     expect(sut.data.data.length).toEqual(1);
   });
+
   it('initial filter from query parameters', () => {
     sut.ngOnInit();
     expect(sut.filter.groups).toEqual(['Cevi']);
     expect(sut.filter.eventType).toEqual('EVENT');
-    expect(sut.nameFilter.getRawValue()).toEqual('abc');
+    expect(sut.filter.nameContains).toEqual('abc');
     expect(sut.filter.kursarten).toEqual(['def']);
     expect(sut.filter.hasAvailablePlaces).toBeTrue();
     expect(sut.filter.isApplicationOpen).toBeTrue();
   });
-  it('translateEventTypes', () => {
-    let result = sut.translateEventTypes('COURSE');
-    expect(result).toEqual('Kurs');
 
-    result = sut.translateEventTypes('EVENT');
-    expect(result).toEqual('Anlass');
-  });
-  it('filterByEventType', () => {
-    const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
-      of(events)
-    );
-    sut.filterByEventType({ value: 'COURSE' } as MatSelectChange);
-    expect(fnc).toHaveBeenCalledWith({
-      eventType: 'COURSE',
-    } as CeviEventFilter);
-  });
-  it('filterByKursart', () => {
-    const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
-      of(events)
-    );
-    sut.filterByKursart({ value: ['J+S', 'GLK'] } as MatSelectChange);
-    expect(fnc).toHaveBeenCalledWith({
-      kursarten: ['J+S', 'GLK'],
-    } as CeviEventFilter);
-  });
-  it('filterByKursart with empty selection sets kursarten to null', () => {
-    const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
-      of(events)
-    );
-    sut.filterByKursart({ value: [] } as MatSelectChange);
-    expect(fnc).toHaveBeenCalledWith({ kursarten: null } as CeviEventFilter);
-  });
-  it('filterByKursart clears activePreset', () => {
-    spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
-    sut.activePreset = KURSART_PRESETS[0];
-    sut.filterByKursart({ value: 'J+S' } as MatSelectChange);
-    expect(sut.activePreset).toBeNull();
-  });
   it('applyPreset sets kursarten and activePreset', () => {
     const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
       of(events)
@@ -163,12 +129,14 @@ describe('EventlistComponent', () => {
       kursarten: preset.kursarten,
     } as CeviEventFilter);
   });
+
   it('applyPreset hides only the clicked chip', () => {
     spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
     sut.applyPreset(KURSART_PRESETS[0]);
     expect(sut.activePreset).toBe(KURSART_PRESETS[0]);
     expect(sut.activePreset).not.toBe(KURSART_PRESETS[1]);
   });
+
   it('applyPreset switches to a different preset', () => {
     spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
     sut.applyPreset(KURSART_PRESETS[0]);
@@ -176,6 +144,7 @@ describe('EventlistComponent', () => {
     expect(sut.activePreset).toBe(KURSART_PRESETS[1]);
     expect(sut.filter.kursarten).toEqual(KURSART_PRESETS[1].kursarten);
   });
+
   it('applyPreset "weitere" filters to kursarten not in named presets', () => {
     spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
     sut.kursarten = [
@@ -186,62 +155,76 @@ describe('EventlistComponent', () => {
     expect(sut.activePreset).toBe('weitere');
     expect(sut.filter.kursarten).toEqual(['Cevi Alpin: Skihochtour']);
   });
-  it('filterByAvailablePlaces', () => {
-    const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
-      of(events)
-    );
-    sut.filterByAvailablePlaces({ value: true } as MatSelectChange);
-    expect(fnc).toHaveBeenCalledWith({
-      hasAvailablePlaces: true,
-    } as CeviEventFilter);
-  });
-  it('filterByIsApplicationOpen', () => {
-    const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
-      of(events)
-    );
-    sut.filterByIsApplicationOpen({ value: true } as MatSelectChange);
-    expect(fnc).toHaveBeenCalledWith({
-      isApplicationOpen: true,
-    } as CeviEventFilter);
-  });
+
   it('hasActiveFilter returns false when no filter is set', () => {
     sut.filter = {} as CeviEventFilter;
     expect(sut.hasActiveFilter).toBeFalse();
   });
+
   it('hasActiveFilter returns true when eventType is set', () => {
     sut.filter = { eventType: 'COURSE' } as CeviEventFilter;
     expect(sut.hasActiveFilter).toBeTrue();
   });
+
   it('hasActiveFilter returns true when groups are set', () => {
     sut.filter = { groups: ['Cevi Alpin'] } as CeviEventFilter;
     expect(sut.hasActiveFilter).toBeTrue();
   });
+
   it('hasActiveFilter returns true when nameContains is set', () => {
     sut.filter = { nameContains: 'GLK' } as CeviEventFilter;
     expect(sut.hasActiveFilter).toBeTrue();
   });
+
   it('hasActiveFilter returns true when kursarten are set', () => {
     sut.filter = { kursarten: ['J+S'] } as CeviEventFilter;
     expect(sut.hasActiveFilter).toBeTrue();
   });
+
   it('hasActiveFilter returns true when hasAvailablePlaces is set', () => {
     sut.filter = { hasAvailablePlaces: true } as CeviEventFilter;
     expect(sut.hasActiveFilter).toBeTrue();
   });
+
   it('hasActiveFilter returns true when isApplicationOpen is set', () => {
     sut.filter = { isApplicationOpen: false } as CeviEventFilter;
     expect(sut.hasActiveFilter).toBeTrue();
   });
+
+  it('activeModalFilterCount returns 0 when no filter is set', () => {
+    sut.filter = {} as CeviEventFilter;
+    expect(sut.activeModalFilterCount).toBe(0);
+  });
+
+  it('activeModalFilterCount counts all active filters', () => {
+    sut.filter = {
+      groups: ['Cevi'],
+      eventType: 'COURSE',
+      nameContains: 'GLK',
+      kursarten: ['J+S'],
+      hasAvailablePlaces: true,
+      isApplicationOpen: false,
+    } as CeviEventFilter;
+    expect(sut.activeModalFilterCount).toBe(6);
+  });
+
+  it('activeModalFilterCount counts partial filters correctly', () => {
+    sut.filter = {
+      eventType: 'COURSE',
+      hasAvailablePlaces: false,
+    } as CeviEventFilter;
+    expect(sut.activeModalFilterCount).toBe(2);
+  });
+
   it('resetFilter clears all filters', () => {
     spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
     sut.ngOnInit();
     sut.activePreset = KURSART_PRESETS[0];
     sut.resetFilter();
     expect(sut.filter).toEqual({} as CeviEventFilter);
-    expect(sut.nameFilter.getRawValue()).toEqual('');
-    expect(sut.organisationFilter.getRawValue()).toEqual([]);
     expect(sut.activePreset).toBeNull();
   });
+
   it('resetFilter reloads events', () => {
     const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
       of(events)
@@ -249,6 +232,7 @@ describe('EventlistComponent', () => {
     sut.resetFilter();
     expect(fnc).toHaveBeenCalledWith({} as CeviEventFilter);
   });
+
   it('resetFilter clears all url params', () => {
     sut.resetFilter();
     expect(router.navigate).toHaveBeenCalledWith(
@@ -266,16 +250,20 @@ describe('EventlistComponent', () => {
       })
     );
   });
+
   it('hasFreeSeats', () => {
     expect(sut.hasFreeSeats(events[0])).toBe('Ja');
   });
+
   it('isApplicationOpen for course with state application_open', () => {
     expect(sut.isApplicationOpen(events[0])).toBe('Ja');
   });
+
   it('isApplicationOpen for course with state application_closed', () => {
     const closedCourse = { ...events[0], state: 'application_closed' };
     expect(sut.isApplicationOpen(closedCourse)).toBe('Nein');
   });
+
   it('isApplicationOpen for event uses date logic', () => {
     const openEvent: CeviEvent = {
       ...events[0],
@@ -287,7 +275,115 @@ describe('EventlistComponent', () => {
     expect(sut.isApplicationOpen(openEvent)).toBe('Ja');
   });
 
-  describe('URL parameter synchronization', () => {
+  describe('openFilterModal', () => {
+    it('opens dialog with FilterModalComponent', () => {
+      sut.ngOnInit();
+      sut.openFilterModal();
+      expect(dialogSpy.open).toHaveBeenCalledWith(
+        FilterModalComponent,
+        jasmine.objectContaining({ width: '520px' })
+      );
+    });
+
+    it('passes current filter state to dialog', () => {
+      sut.filter = { eventType: 'COURSE' } as CeviEventFilter;
+      sut.openFilterModal();
+      const data = dialogSpy.open.calls.mostRecent().args[1]?.data as { filter: CeviEventFilter };
+      expect(data.filter).toEqual(jasmine.objectContaining({ eventType: 'COURSE' }));
+    });
+
+    it('onFilterChange updates filter and reloads events', () => {
+      const fnc = spyOn(eventService, 'getEventsWithFilter').and.returnValue(
+        of(events)
+      );
+      let capturedOnFilterChange:
+        | ((f: CeviEventFilter) => void)
+        | undefined;
+      dialogSpy.open.and.callFake(
+        (_comp: unknown, config: { data?: { onFilterChange?: (f: CeviEventFilter) => void } }) => {
+          capturedOnFilterChange = config?.data?.onFilterChange;
+          return {} as any;
+        }
+      );
+
+      sut.openFilterModal();
+      const newFilter = { eventType: 'COURSE' } as CeviEventFilter;
+      capturedOnFilterChange?.(newFilter);
+
+      expect(sut.filter).toBe(newFilter);
+      expect(fnc).toHaveBeenCalledWith(newFilter);
+    });
+
+    it('onFilterChange clears activePreset when kursarten reference changes', () => {
+      spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
+      sut.activePreset = KURSART_PRESETS[0];
+      sut.filter = { kursarten: ['J+S'] } as CeviEventFilter;
+
+      let capturedOnFilterChange:
+        | ((f: CeviEventFilter) => void)
+        | undefined;
+      dialogSpy.open.and.callFake(
+        (_comp: unknown, config: { data?: { onFilterChange?: (f: CeviEventFilter) => void } }) => {
+          capturedOnFilterChange = config?.data?.onFilterChange;
+          return {} as any;
+        }
+      );
+
+      sut.openFilterModal();
+      capturedOnFilterChange?.({ kursarten: ['GLK'] } as CeviEventFilter);
+
+      expect(sut.activePreset).toBeNull();
+    });
+
+    it('onFilterChange preserves activePreset when kursarten reference is unchanged', () => {
+      spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
+      const kursarten = ['J+S'];
+      sut.activePreset = KURSART_PRESETS[0];
+      sut.filter = { kursarten } as CeviEventFilter;
+
+      let capturedOnFilterChange:
+        | ((f: CeviEventFilter) => void)
+        | undefined;
+      dialogSpy.open.and.callFake(
+        (_comp: unknown, config: { data?: { onFilterChange?: (f: CeviEventFilter) => void } }) => {
+          capturedOnFilterChange = config?.data?.onFilterChange;
+          return {} as any;
+        }
+      );
+
+      sut.openFilterModal();
+      // Same kursarten reference (modal only changed organisation, not kursarten)
+      capturedOnFilterChange?.({ kursarten, eventType: 'COURSE' } as CeviEventFilter);
+
+      expect(sut.activePreset).toBe(KURSART_PRESETS[0]);
+    });
+
+    it('onFilterChange updates url params', () => {
+      spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
+      let capturedOnFilterChange:
+        | ((f: CeviEventFilter) => void)
+        | undefined;
+      dialogSpy.open.and.callFake(
+        (_comp: unknown, config: { data?: { onFilterChange?: (f: CeviEventFilter) => void } }) => {
+          capturedOnFilterChange = config?.data?.onFilterChange;
+          return {} as any;
+        }
+      );
+
+      sut.openFilterModal();
+      capturedOnFilterChange?.({ eventType: 'COURSE' } as CeviEventFilter);
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        [],
+        jasmine.objectContaining({
+          queryParams: jasmine.objectContaining({ type: 'COURSE' }),
+          replaceUrl: true,
+        })
+      );
+    });
+  });
+
+  describe('URL parameter synchronization via applyPreset', () => {
     const expectNavigate = (queryParams: Record<string, unknown>) =>
       expect(router.navigate).toHaveBeenCalledWith(
         [],
@@ -297,65 +393,12 @@ describe('EventlistComponent', () => {
         })
       );
 
-    it('filterByEventType updates url', () => {
-      sut.filterByEventType({ value: 'COURSE' } as MatSelectChange);
-      expectNavigate({ type: 'COURSE' });
-    });
-    it('filterByEventType clears url param when null', () => {
-      sut.filterByEventType({ value: null } as MatSelectChange);
-      expectNavigate({ type: null });
-    });
-    it('filterByKursart updates url', () => {
-      sut.filterByKursart({ value: ['GLK', 'J+S'] } as MatSelectChange);
-      expectNavigate({ kursart: ['GLK', 'J+S'] });
-    });
-    it('filterByKursart clears url param on empty selection', () => {
-      sut.filterByKursart({ value: [] } as MatSelectChange);
-      expectNavigate({ kursart: null });
-    });
-    it('filterByAvailablePlaces updates url with true', () => {
-      sut.filterByAvailablePlaces({ value: true } as MatSelectChange);
-      expectNavigate({ freeSeats: 'true' });
-    });
-    it('filterByAvailablePlaces updates url with false', () => {
-      sut.filterByAvailablePlaces({ value: false } as MatSelectChange);
-      expectNavigate({ freeSeats: 'false' });
-    });
-    it('filterByAvailablePlaces clears url param when null', () => {
-      sut.filterByAvailablePlaces({ value: null } as MatSelectChange);
-      expectNavigate({ freeSeats: null });
-    });
-    it('filterByIsApplicationOpen updates url with false', () => {
-      sut.filterByIsApplicationOpen({ value: false } as MatSelectChange);
-      expectNavigate({ applicationOpen: 'false' });
-    });
-    it('filterByIsApplicationOpen clears url param when null', () => {
-      sut.filterByIsApplicationOpen({ value: null } as MatSelectChange);
-      expectNavigate({ applicationOpen: null });
-    });
     it('applyPreset updates url', () => {
+      spyOn(eventService, 'getEventsWithFilter').and.returnValue(of(events));
       const preset = KURSART_PRESETS[0];
       sut.applyPreset(preset);
       expectNavigate({ kursart: preset.kursarten });
     });
-    it('organisationFilter change updates url', () => {
-      sut.organisationFilter.setValue(['Cevi Alpin']);
-      expectNavigate({ organisation: ['Cevi Alpin'] });
-    });
-    it('organisationFilter empty selection clears url param', () => {
-      sut.organisationFilter.setValue([]);
-      expectNavigate({ organisation: null });
-    });
-    it('nameFilter change updates url', fakeAsync(() => {
-      sut.nameFilter.setValue('GLK');
-      tick(400);
-      expectNavigate({ text: 'GLK' });
-    }));
-    it('nameFilter empty string clears url param', fakeAsync(() => {
-      sut.nameFilter.setValue('');
-      tick(400);
-      expectNavigate({ text: null });
-    }));
   });
 });
 
@@ -386,6 +429,10 @@ describe('EventlistComponent – multiple kursart query parameters', () => {
           useValue: {
             queryParamMap: of(convertToParamMap({ kursart: ['GLK', 'J+S'] })),
           },
+        },
+        {
+          provide: MatDialog,
+          useValue: jasmine.createSpyObj('MatDialog', ['open']),
         },
       ],
     }).compileComponents();

--- a/frontend/src/app/event/components/eventlist.component.ts
+++ b/frontend/src/app/event/components/eventlist.component.ts
@@ -1,19 +1,15 @@
 import { Component, OnInit, ViewChild, inject } from '@angular/core';
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatExpansionModule } from '@angular/material/expansion';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableDataSource, MatTableModule } from '@angular/material/table';
-import { debounceTime, distinctUntilChanged } from 'rxjs';
-import { SelectCheckAllComponent } from '../../core/components/select-check-all.component';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatDialog } from '@angular/material/dialog';
 import { parseIsoDate } from '../../util/date.util';
 import { EventDateTimeFormatterPipe } from '../pipes/event-date-time-formatter.pipe';
 import {
@@ -31,24 +27,20 @@ import {
   KursartPreset,
   KURSART_PRESETS,
 } from '../models/kursart-preset';
+import { FilterModalComponent } from './filter-modal.component';
 
 @Component({
   selector: 'app-event-list',
   imports: [
-    SelectCheckAllComponent,
     MatButtonModule,
     MatIconModule,
     MatChipsModule,
+    MatBadgeModule,
     MatProgressSpinnerModule,
     MatTableModule,
     MatSortModule,
     MatPaginatorModule,
-    MatFormFieldModule,
-    MatSelectModule,
-    MatInputModule,
-    FormsModule,
     MatExpansionModule,
-    ReactiveFormsModule,
     EventDateTimeFormatterPipe,
   ],
   templateUrl: './eventlist.component.html',
@@ -59,6 +51,7 @@ export class EventListComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly masterdataService = inject(MasterdataService);
+  private readonly dialog = inject(MatDialog);
 
   readonly KURSART_PRESETS = KURSART_PRESETS;
 
@@ -82,8 +75,6 @@ export class EventListComponent implements OnInit {
     'applicationOpen',
     'link',
   ];
-  public nameFilter!: FormControl;
-  public organisationFilter!: FormControl;
 
   private sort!: MatSort;
   private paginator!: MatPaginator;
@@ -98,34 +89,16 @@ export class EventListComponent implements OnInit {
     this.data.paginator = this.paginator;
   }
 
-  constructor() {
-    this.nameFilter = new FormControl('');
-    this.organisationFilter = new FormControl(this.organisations);
-    this.organisationFilter.valueChanges.subscribe(value => {
-      this.filter.groups = value;
-      this.loadEventsWithFilter();
-      this.updateUrlParams();
-    });
-
-    this.nameFilter.valueChanges
-      .pipe(debounceTime(400), distinctUntilChanged())
-      .subscribe(value => {
-        this.filter.nameContains = value;
-        this.loadEventsWithFilter();
-        this.updateUrlParams();
-      });
-  }
-
   ngOnInit(): void {
     this.route.queryParamMap.subscribe(params => {
       if (params.has('organisation')) {
-        this.organisationFilter.setValue(params.getAll('organisation'));
+        this.filter.groups = params.getAll('organisation');
       }
       if (params.has('type')) {
         this.filter.eventType = params.get('type') as CeviEventType;
       }
       if (params.has('text')) {
-        this.nameFilter.setValue(params.get('text'));
+        this.filter.nameContains = params.get('text');
       }
       if (params.has('kursart')) {
         this.filter.kursarten = params.getAll('kursart');
@@ -142,10 +115,10 @@ export class EventListComponent implements OnInit {
     this.loadEventsWithFilter();
 
     this.masterdataService.getMasterdata().subscribe({
-      next: (data: Masterdata) => {
-        this.organisations = data.organisations.map(o => o.name);
-        this.types = data.eventTypes;
-        this.kursarten = data.kursarten.map(k => k.name);
+      next: (masterdata: Masterdata) => {
+        this.organisations = masterdata.organisations.map(o => o.name);
+        this.types = masterdata.eventTypes;
+        this.kursarten = masterdata.kursarten.map(k => k.name);
         this.isLoadingMasterdata = false;
       },
       error: () => {
@@ -155,20 +128,24 @@ export class EventListComponent implements OnInit {
     });
   }
 
-  translateEventTypes(eventType: string): string {
-    if (eventType === 'COURSE') {
-      return $localize`:@@eventType.course:Kurs`;
-    } else if (eventType === 'EVENT') {
-      return $localize`:@@eventType.event:Anlass`;
-    } else {
-      return eventType;
-    }
-  }
-
-  filterByEventType($event: MatSelectChange) {
-    this.filter.eventType = $event.value;
-    this.loadEventsWithFilter();
-    this.updateUrlParams();
+  openFilterModal(): void {
+    this.dialog.open(FilterModalComponent, {
+      data: {
+        filter: { ...this.filter },
+        organisations: this.organisations,
+        kursarten: this.kursarten,
+        types: this.types,
+        onFilterChange: (updated: CeviEventFilter) => {
+          if (updated.kursarten !== this.filter.kursarten) {
+            this.activePreset = null;
+          }
+          this.filter = updated;
+          this.loadEventsWithFilter();
+          this.updateUrlParams();
+        },
+      },
+      width: '520px',
+    });
   }
 
   applyPreset(preset: KursartPreset | 'weitere') {
@@ -177,25 +154,6 @@ export class EventListComponent implements OnInit {
       preset === 'weitere'
         ? this.kursarten.filter(k => !ALL_NAMED_PRESET_KURSARTEN.includes(k))
         : preset.kursarten;
-    this.loadEventsWithFilter();
-    this.updateUrlParams();
-  }
-
-  filterByKursart($event: MatSelectChange) {
-    this.activePreset = null;
-    this.filter.kursarten = $event.value?.length ? $event.value : null;
-    this.loadEventsWithFilter();
-    this.updateUrlParams();
-  }
-
-  filterByAvailablePlaces($event: MatSelectChange) {
-    this.filter.hasAvailablePlaces = $event.value;
-    this.loadEventsWithFilter();
-    this.updateUrlParams();
-  }
-
-  filterByIsApplicationOpen($event: MatSelectChange) {
-    this.filter.isApplicationOpen = $event.value;
     this.loadEventsWithFilter();
     this.updateUrlParams();
   }
@@ -211,10 +169,19 @@ export class EventListComponent implements OnInit {
     );
   }
 
+  get activeModalFilterCount(): number {
+    let count = 0;
+    if (this.filter.groups?.length) count++;
+    if (this.filter.eventType) count++;
+    if (this.filter.nameContains?.trim().length) count++;
+    if (this.filter.kursarten?.length) count++;
+    if (this.filter.hasAvailablePlaces != null) count++;
+    if (this.filter.isApplicationOpen != null) count++;
+    return count;
+  }
+
   resetFilter() {
     this.filter = {} as CeviEventFilter;
-    this.nameFilter.setValue('', { emitEvent: false });
-    this.organisationFilter.setValue([], { emitEvent: false });
     this.activePreset = null;
     this.loadEventsWithFilter();
     this.updateUrlParams();

--- a/frontend/src/app/event/components/filter-modal.component.html
+++ b/frontend/src/app/event/components/filter-modal.component.html
@@ -1,0 +1,74 @@
+<h2 mat-dialog-title i18n="@@filter.modalTitle">Filter</h2>
+<mat-dialog-content>
+  <div class="filter-modal__row">
+    <span class="filter-modal__label" i18n="@@filter.organisation">Organisation</span>
+    <mat-form-field class="filter-modal__field">
+      <mat-select multiple [formControl]="organisationFilter">
+        <app-select-check-all
+          [model]="organisationFilter"
+          [values]="data.organisations">
+        </app-select-check-all>
+        @for (org of data.organisations; track org) {
+          <mat-option [value]="org">{{ org }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div class="filter-modal__row">
+    <span class="filter-modal__label" i18n="@@filter.type">Typ</span>
+    <mat-chip-listbox
+      [value]="localFilter.eventType"
+      (change)="setEventType($event)">
+      @for (type of data.types; track type) {
+        <mat-chip-option [value]="type">{{ translateEventType(type) }}</mat-chip-option>
+      }
+    </mat-chip-listbox>
+  </div>
+
+  <div class="filter-modal__row">
+    <span class="filter-modal__label" i18n="@@filter.nameSearch">Text im Name</span>
+    <mat-form-field class="filter-modal__field">
+      <input type="text" [formControl]="nameFilter" matInput />
+    </mat-form-field>
+  </div>
+
+  <div class="filter-modal__row">
+    <span class="filter-modal__label" i18n="@@filter.kursart">Kursart</span>
+    <mat-form-field class="filter-modal__field">
+      <mat-select
+        multiple
+        (selectionChange)="setKursarten($event)"
+        [value]="localFilter.kursarten ?? []">
+        @for (kursart of data.kursarten; track kursart) {
+          <mat-option [value]="kursart">{{ kursart }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div class="filter-modal__row">
+    <span class="filter-modal__label" i18n="@@filter.freeSeats">Freie Plätze</span>
+    <mat-chip-listbox
+      [value]="localFilter.hasAvailablePlaces"
+      (change)="setHasAvailablePlaces($event)">
+      <mat-chip-option [value]="true" i18n="@@common.yes">Ja</mat-chip-option>
+      <mat-chip-option [value]="false" i18n="@@common.no">Nein</mat-chip-option>
+    </mat-chip-listbox>
+  </div>
+
+  <div class="filter-modal__row">
+    <span class="filter-modal__label" i18n="@@filter.applicationOpen"
+      >Offen zur Anmeldung</span
+    >
+    <mat-chip-listbox
+      [value]="localFilter.isApplicationOpen"
+      (change)="setIsApplicationOpen($event)">
+      <mat-chip-option [value]="true" i18n="@@common.yes">Ja</mat-chip-option>
+      <mat-chip-option [value]="false" i18n="@@common.no">Nein</mat-chip-option>
+    </mat-chip-listbox>
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close i18n="@@filter.close">Schliessen</button>
+</mat-dialog-actions>

--- a/frontend/src/app/event/components/filter-modal.component.scss
+++ b/frontend/src/app/event/components/filter-modal.component.scss
@@ -1,0 +1,18 @@
+.filter-modal {
+  &__row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 8px;
+  }
+
+  &__label {
+    width: 160px;
+    flex-shrink: 0;
+    font-weight: 500;
+  }
+
+  &__field {
+    flex: 1;
+  }
+}

--- a/frontend/src/app/event/components/filter-modal.component.spec.ts
+++ b/frontend/src/app/event/components/filter-modal.component.spec.ts
@@ -1,0 +1,169 @@
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
+import { FilterModalComponent } from './filter-modal.component';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatChipListboxChange } from '@angular/material/chips';
+import { MatSelectChange } from '@angular/material/select';
+import { CeviEventFilter } from '../services/event.service';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+describe('FilterModalComponent', () => {
+  let fixture: ComponentFixture<FilterModalComponent>;
+  let sut: FilterModalComponent;
+  let onFilterChange: jasmine.Spy;
+
+  const initialFilter: CeviEventFilter = {
+    groups: ['Cevi'],
+    eventType: null,
+    nameContains: 'test',
+    kursarten: null,
+    hasAvailablePlaces: null,
+    isApplicationOpen: null,
+    earliestStartAt: null,
+    latestStartAt: null,
+  };
+
+  beforeEach(async () => {
+    onFilterChange = jasmine.createSpy('onFilterChange');
+
+    await TestBed.configureTestingModule({
+      imports: [FilterModalComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            filter: initialFilter,
+            organisations: ['Cevi', 'CVJM'],
+            kursarten: ['Kurs A', 'Kurs B'],
+            types: ['COURSE', 'EVENT'],
+            onFilterChange,
+          },
+        },
+        { provide: MatDialogRef, useValue: {} },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilterModalComponent);
+    sut = fixture.componentInstance;
+  });
+
+  it('initializes localFilter from data.filter', () => {
+    expect(sut.localFilter.groups).toEqual(['Cevi']);
+    expect(sut.localFilter.nameContains).toEqual('test');
+  });
+
+  it('initializes nameFilter with filter.nameContains', () => {
+    expect(sut.nameFilter.getRawValue()).toEqual('test');
+  });
+
+  it('initializes organisationFilter with filter.groups', () => {
+    expect(sut.organisationFilter.getRawValue()).toEqual(['Cevi']);
+  });
+
+  it('does not call onFilterChange during initialization', () => {
+    expect(onFilterChange).not.toHaveBeenCalled();
+  });
+
+  it('setEventType calls onFilterChange with correct eventType', () => {
+    sut.setEventType({ value: 'COURSE' } as MatChipListboxChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ eventType: 'COURSE' })
+    );
+  });
+
+  it('setEventType with undefined sets eventType to null', () => {
+    sut.setEventType({ value: undefined } as MatChipListboxChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ eventType: null })
+    );
+  });
+
+  it('setHasAvailablePlaces calls onFilterChange with true', () => {
+    sut.setHasAvailablePlaces({ value: true } as MatChipListboxChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ hasAvailablePlaces: true })
+    );
+  });
+
+  it('setHasAvailablePlaces calls onFilterChange with false', () => {
+    sut.setHasAvailablePlaces({ value: false } as MatChipListboxChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ hasAvailablePlaces: false })
+    );
+  });
+
+  it('setHasAvailablePlaces with undefined sets to null', () => {
+    sut.setHasAvailablePlaces({ value: undefined } as MatChipListboxChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ hasAvailablePlaces: null })
+    );
+  });
+
+  it('setIsApplicationOpen calls onFilterChange with false', () => {
+    sut.setIsApplicationOpen({ value: false } as MatChipListboxChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ isApplicationOpen: false })
+    );
+  });
+
+  it('setIsApplicationOpen with undefined sets to null', () => {
+    sut.setIsApplicationOpen({ value: undefined } as MatChipListboxChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ isApplicationOpen: null })
+    );
+  });
+
+  it('setKursarten calls onFilterChange with kursarten', () => {
+    sut.setKursarten({ value: ['Kurs A'] } as MatSelectChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ kursarten: ['Kurs A'] })
+    );
+  });
+
+  it('setKursarten with empty array sets kursarten to null', () => {
+    sut.setKursarten({ value: [] } as MatSelectChange);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ kursarten: null })
+    );
+  });
+
+  it('organisationFilter change calls onFilterChange immediately', () => {
+    sut.organisationFilter.setValue(['CVJM']);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ groups: ['CVJM'] })
+    );
+  });
+
+  it('nameFilter change calls onFilterChange after debounce', fakeAsync(() => {
+    sut.nameFilter.setValue('search');
+    tick(400);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ nameContains: 'search' })
+    );
+  }));
+
+  it('nameFilter empty string sets nameContains to null', fakeAsync(() => {
+    sut.nameFilter.setValue('');
+    tick(400);
+    expect(onFilterChange).toHaveBeenCalledWith(
+      jasmine.objectContaining({ nameContains: null })
+    );
+  }));
+
+  it('translateEventType returns Kurs for COURSE', () => {
+    expect(sut.translateEventType('COURSE')).toEqual('Kurs');
+  });
+
+  it('translateEventType returns Anlass for EVENT', () => {
+    expect(sut.translateEventType('EVENT')).toEqual('Anlass');
+  });
+
+  it('translateEventType returns raw value for unknown type', () => {
+    expect(sut.translateEventType('UNKNOWN')).toEqual('UNKNOWN');
+  });
+});

--- a/frontend/src/app/event/components/filter-modal.component.ts
+++ b/frontend/src/app/event/components/filter-modal.component.ts
@@ -1,0 +1,102 @@
+import { Component, inject } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatChipsModule,
+  MatChipListboxChange,
+} from '@angular/material/chips';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule, MatSelectChange } from '@angular/material/select';
+import { debounceTime, distinctUntilChanged } from 'rxjs';
+import { SelectCheckAllComponent } from '../../core/components/select-check-all.component';
+import { CeviEventFilter } from '../services/event.service';
+
+export interface FilterModalData {
+  filter: CeviEventFilter;
+  organisations: string[];
+  kursarten: string[];
+  types: string[];
+  onFilterChange: (f: CeviEventFilter) => void;
+}
+
+@Component({
+  selector: 'app-filter-modal',
+  imports: [
+    MatDialogModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    FormsModule,
+    ReactiveFormsModule,
+    SelectCheckAllComponent,
+  ],
+  templateUrl: './filter-modal.component.html',
+  styleUrls: ['./filter-modal.component.scss'],
+})
+export class FilterModalComponent {
+  readonly data = inject<FilterModalData>(MAT_DIALOG_DATA);
+
+  localFilter: CeviEventFilter;
+  readonly nameFilter: FormControl;
+  readonly organisationFilter: FormControl;
+
+  constructor() {
+    this.localFilter = { ...this.data.filter };
+    this.nameFilter = new FormControl(this.data.filter.nameContains ?? '');
+    this.organisationFilter = new FormControl(this.data.filter.groups ?? []);
+
+    this.organisationFilter.valueChanges.subscribe((value: string[]) => {
+      this.localFilter = { ...this.localFilter, groups: value };
+      this.data.onFilterChange({ ...this.localFilter });
+    });
+
+    this.nameFilter.valueChanges
+      .pipe(debounceTime(400), distinctUntilChanged())
+      .subscribe((value: string) => {
+        this.localFilter = {
+          ...this.localFilter,
+          nameContains: value?.trim() || null,
+        };
+        this.data.onFilterChange({ ...this.localFilter });
+      });
+  }
+
+  setEventType(event: MatChipListboxChange): void {
+    this.localFilter = { ...this.localFilter, eventType: event.value ?? null };
+    this.data.onFilterChange({ ...this.localFilter });
+  }
+
+  setKursarten(event: MatSelectChange): void {
+    this.localFilter = {
+      ...this.localFilter,
+      kursarten: event.value?.length ? event.value : null,
+    };
+    this.data.onFilterChange({ ...this.localFilter });
+  }
+
+  setHasAvailablePlaces(event: MatChipListboxChange): void {
+    this.localFilter = {
+      ...this.localFilter,
+      hasAvailablePlaces: event.value ?? null,
+    };
+    this.data.onFilterChange({ ...this.localFilter });
+  }
+
+  setIsApplicationOpen(event: MatChipListboxChange): void {
+    this.localFilter = {
+      ...this.localFilter,
+      isApplicationOpen: event.value ?? null,
+    };
+    this.data.onFilterChange({ ...this.localFilter });
+  }
+
+  translateEventType(type: string): string {
+    if (type === 'COURSE') return $localize`:@@eventType.course:Kurs`;
+    if (type === 'EVENT') return $localize`:@@eventType.event:Anlass`;
+    return type;
+  }
+}

--- a/frontend/src/locale/messages.fr.xlf
+++ b/frontend/src/locale/messages.fr.xlf
@@ -70,6 +70,18 @@
         <source>Filter:</source>
         <target>Filtres :</target>
       </trans-unit>
+      <trans-unit id="filter.moreFilters" datatype="html">
+        <source>Weitere Filter</source>
+        <target>Plus de filtres</target>
+      </trans-unit>
+      <trans-unit id="filter.modalTitle" datatype="html">
+        <source>Filter</source>
+        <target>Filtres</target>
+      </trans-unit>
+      <trans-unit id="filter.close" datatype="html">
+        <source>Schliessen</source>
+        <target>Fermer</target>
+      </trans-unit>
       <trans-unit id="filter.reset" datatype="html">
         <source>Filter zurücksetzen</source>
         <target>Réinitialiser les filtres</target>

--- a/frontend/src/locale/messages.xlf
+++ b/frontend/src/locale/messages.xlf
@@ -121,6 +121,27 @@
           <context context-type="linenumber">24,26</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="filter.moreFilters" datatype="html">
+        <source>Weitere Filter</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/event/components/eventlist.component.html</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="filter.modalTitle" datatype="html">
+        <source>Filter</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/event/components/filter-modal.component.html</context>
+          <context context-type="linenumber">1</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="filter.close" datatype="html">
+        <source>Schliessen</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/event/components/filter-modal.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="filter.reset" datatype="html">
         <source>Filter zurücksetzen</source>
         <context-group purpose="location">

--- a/git-commit-message.md
+++ b/git-commit-message.md
@@ -1,0 +1,3 @@
+feat(frontend): implement filter modal (#234)
+
+Move all filters into a dedicated modal dialog opened via a new "Weitere Filter" button. The preset chips remain in the main view. A MatBadge on the button shows the number of active filters. Every filter change in the modal is applied immediately. The "Filter zurücksetzen" button stays in the main toolbar next to the new button.


### PR DESCRIPTION
Move all filters into a dedicated modal dialog opened via a new "Weitere Filter" button. The preset chips remain in the main view. A MatBadge on the button shows the number of active filters. Every filter change in the modal is applied immediately. The "Filter zurücksetzen" button stays in the main toolbar next to the new button.